### PR TITLE
logging the flow for bundle install

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -184,6 +184,8 @@ module Bundler
 
       If the bundle has already been installed, bundler will tell you so and then exit.
     D
+    method_option "avoid", :type => :array, :banner =>
+      "Exclude individual gems that are specified by name."
     method_option "binstubs", :type => :string, :lazy_default => "bin", :banner =>
       "Generate bin stubs for bundled gems to ./bin"
     method_option "clean", :type => :boolean, :banner =>

--- a/lib/bundler/cli/install.rb
+++ b/lib/bundler/cli/install.rb
@@ -8,6 +8,14 @@ module Bundler
     end
 
     def run
+      puts '----'
+      puts 'In run method CLI install: '
+
+      puts 'OPTIONS: '
+      p @options
+      puts '----'
+
+
       Bundler.ui.level = "error" if options[:quiet]
 
       warn_if_root
@@ -56,13 +64,17 @@ module Bundler
         Bundler::SharedHelpers.major_deprecation 2,
           "The --binstubs option will be removed in favor of `bundle binstubs`"
       end
-
       Plugin.gemfile_install(Bundler.default_gemfile) if Bundler.feature_flag.plugins?
-
+      p 'AFTER when does definition get created?'
       definition = Bundler.definition
       definition.validate_runtime!
 
+      p "---"
+      p 'in CLI::Installer, after definition'
+      p definition
+      p options
       installer = Installer.install(Bundler.root, definition, options)
+
       Bundler.load.cache if Bundler.app_cache.exist? && !options["no-cache"] && !Bundler.frozen_bundle?
 
       Bundler.ui.confirm "Bundle complete! #{dependencies_count_for(definition)}, #{gems_installed_for(definition)}."
@@ -83,6 +95,7 @@ module Bundler
         require_relative "clean"
         Bundler::CLI::Clean.new(options).run
       end
+      p "install.rb THE END"
     rescue GemNotFound, VersionConflict => e
       if options[:local] && Bundler.app_cache.exist?
         Bundler.ui.warn "Some gems seem to be missing from your #{Bundler.settings.app_cache_path} directory."

--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -30,7 +30,7 @@ module Bundler
       gemfile = Pathname.new(gemfile).expand_path
 
       raise GemfileNotFound, "#{gemfile} not found" unless gemfile.file?
-
+      p 'definition: calling Dsl.evaluate'
       Dsl.evaluate(gemfile, lockfile, unlock)
     end
 
@@ -53,6 +53,8 @@ module Bundler
     # @param ruby_version [Bundler::RubyVersion, nil] Requested Ruby Version
     # @param optional_groups [Array(String)] A list of optional groups
     def initialize(lockfile, dependencies, sources, unlock, ruby_version = nil, optional_groups = [], gemfiles = [])
+      p 'definition.rb: WHEN IS THIS?'
+      p dependencies
       if [true, false].include?(unlock)
         @unlocking_bundler = false
         @unlocking = unlock
@@ -89,14 +91,19 @@ module Bundler
         if unlock != true
           @locked_deps    = @locked_gems.dependencies
           @locked_specs   = SpecSet.new(@locked_gems.specs)
+          p 'if unlock is not true, in definitin#initialize'
+          p @locked_gems.specs
+          p @locked_specs
           @locked_sources = @locked_gems.sources
         else
+          p 'if unlock is true, in definitin#initialize'
           @unlock         = {}
           @locked_deps    = {}
           @locked_specs   = SpecSet.new([])
           @locked_sources = []
         end
       else
+        p 'if no lockfile, in definitin#initialize'
         @unlock         = {}
         @platforms      = []
         @locked_gems    = nil
@@ -265,6 +272,7 @@ module Bundler
     end
 
     def index
+      p 'definition#index'
       @index ||= Index.build do |idx|
         dependency_names = @dependencies.map(&:name)
 

--- a/lib/bundler/dependency.rb
+++ b/lib/bundler/dependency.rb
@@ -84,10 +84,13 @@ module Bundler
     end.freeze
 
     def initialize(name, version, options = {}, &blk)
+      p 'dependency#initialize'
+      p name, version, type
       type = options["type"] || :runtime
       super(name, version, type)
 
       @autorequire    = nil
+      @avoid          = false
       @groups         = Array(options["group"] || :default).map(&:to_sym)
       @source         = options["source"]
       @git            = options["git"]
@@ -98,6 +101,16 @@ module Bundler
       @gemfile        = options["gemfile"]
 
       @autorequire = Array(options["require"] || []) if options.key?("require")
+    end
+
+    # is this a useful place to set state, or is there a better place?
+    def avoid?
+      @avoid
+    end
+
+    def avoid
+      p 'calling avoid'
+      @avoid = true
     end
 
     # Returns the platforms this dependency is valid for, in the same order as

--- a/lib/bundler/deployment.rb
+++ b/lib/bundler/deployment.rb
@@ -51,6 +51,7 @@ module Bundler
           bundle_gemfile = context.fetch(:bundle_gemfile, "Gemfile")
           bundle_without = [*context.fetch(:bundle_without, [:development, :test])].compact
           bundle_with    = [*context.fetch(:bundle_with, [])].compact
+          # bundle_avoid   = [*context.fetch(:bundle_avoid, [])].compact
           app_path = context.fetch(:latest_release)
           if app_path.to_s.empty?
             raise error_type.new("Cannot detect current release path - make sure you have deployed at least once.")
@@ -60,6 +61,7 @@ module Bundler
           args << bundle_flags.to_s
           args << "--without #{bundle_without.join(" ")}" unless bundle_without.empty?
           args << "--with #{bundle_with.join(" ")}" unless bundle_with.empty?
+          # args << "--avoid #{bundle_avoid.join(" ")}" unless bundle_avoid.empty?
 
           run "cd #{app_path} && #{bundle_cmd} install #{args.join(" ")}"
         end

--- a/lib/bundler/env.rb
+++ b/lib/bundler/env.rb
@@ -49,6 +49,7 @@ module Bundler
       end
 
       if print_gemspecs
+        p "\t\tin env.rb: creating dsl"
         dsl = Dsl.new.tap {|d| d.eval_gemfile(Bundler.default_gemfile) }
         out << "\n## Gemspecs\n" unless dsl.gemspecs.empty?
         dsl.gemspecs.each do |gs|

--- a/lib/bundler/installer/gem_installer.rb
+++ b/lib/bundler/installer/gem_installer.rb
@@ -64,6 +64,9 @@ module Bundler
     end
 
     def install
+      p "in gem installer"
+      p spec
+      return if spec.name == 'rack'
       spec.source.install(spec, :force => force, :ensure_builtin_gems_cached => standalone, :build_args => Array(spec_settings))
     end
 

--- a/lib/bundler/plugin.rb
+++ b/lib/bundler/plugin.rb
@@ -74,6 +74,8 @@ module Bundler
     # @param [Proc] block that can be evaluated for (inline) Gemfile
     def gemfile_install(gemfile = nil, &inline)
       Bundler.settings.temporary(:frozen => false, :deployment => false) do
+
+        p 'plugin.rb: create dsl and definition'
         builder = DSL.new
         if block_given?
           builder.instance_eval(&inline)
@@ -81,9 +83,9 @@ module Bundler
           builder.eval_gemfile(gemfile)
         end
         definition = builder.to_definition(nil, true)
-
+        print 'empty: ', definition, "\n"
         return if definition.dependencies.empty?
-
+        p 'empty dependencies, so not printed'
         plugins = definition.dependencies.map(&:name).reject {|p| index.installed? p }
         installed_specs = Installer.new.install_definition(definition)
 

--- a/lib/bundler/plugin/installer.rb
+++ b/lib/bundler/plugin/installer.rb
@@ -83,6 +83,7 @@ module Bundler
 
         deps = names.map {|name| Dependency.new name, version }
 
+        p '********in the plugin installer'
         definition = Definition.new(nil, deps, source_list, true)
         install_definition(definition)
       end

--- a/lib/bundler/resolver.rb
+++ b/lib/bundler/resolver.rb
@@ -17,6 +17,11 @@ module Bundler
     #   collection of gemspecs is returned. Otherwise, nil is returned.
     def self.resolve(requirements, index, source_requirements = {}, base = [], gem_version_promoter = GemVersionPromoter.new, additional_base_requirements = [], platforms = nil)
       platforms = Set.new(platforms) if platforms
+      p '-----in resolver-----'
+      p 'source reqs'
+      source_requirements.each { |key, value| p value.dependency_names }
+      p 'reqs'
+      requirements.each { |req| p req.name }
       base = SpecSet.new(base) unless base.is_a?(SpecSet)
       resolver = new(index, source_requirements, base, gem_version_promoter, additional_base_requirements, platforms)
       result = resolver.start(requirements)
@@ -26,6 +31,7 @@ module Bundler
     def initialize(index, source_requirements, base, gem_version_promoter, additional_base_requirements, platforms)
       @index = index
       @source_requirements = source_requirements
+      # @source_requirements.each { |key, value| p value.dependency_names }
       @base = base
       @resolver = Molinillo::Resolver.new(self, self)
       @search_for = {}
@@ -43,6 +49,8 @@ module Bundler
     end
 
     def start(requirements)
+      p 'in resolver #start'
+      p requirements
       @gem_version_promoter.prerelease_specified = @prerelease_specified = {}
       requirements.each {|dep| @prerelease_specified[dep.name] ||= dep.prerelease? }
 

--- a/lib/bundler/spec_set.rb
+++ b/lib/bundler/spec_set.rb
@@ -9,6 +9,7 @@ module Bundler
     include TSort
 
     def initialize(specs)
+      p 'bundler::specset: when is the specset created?'
       @specs = specs
     end
 

--- a/man/bundle-install.1.txt
+++ b/man/bundle-install.1.txt
@@ -30,8 +30,11 @@ DESCRIPTION
        below under CONSERVATIVE UPDATING.
 
 OPTIONS
-       To  apply  any  of --binstubs, --deployment, --path, or --without every
-       time bundle install is run, use bundle config (see bundle-config(1)).
+       To  apply  any  of --avoid, --binstubs, --deployment, --path, or --without
+       every time bundle install is run, use bundle config (see bundle-config(1)).
+
+       --avoid=[<list>]
+         A space-separated list of gems to skip during installation.
 
        --binstubs[=<directory>]
 	      Binstubs are scripts that wrap around executables. Bundler  cre-

--- a/man/bundle-install.ronn
+++ b/man/bundle-install.ronn
@@ -3,7 +3,8 @@ bundle-install(1) -- Install the dependencies specified in your Gemfile
 
 ## SYNOPSIS
 
-`bundle install` [--binstubs[=DIRECTORY]]
+`bundle install` [--avoid=[GEMS]]
+                 [--binstubs[=DIRECTORY]]
                  [--clean]
                  [--deployment]
                  [--frozen]
@@ -45,6 +46,9 @@ update process below under [CONSERVATIVE UPDATING][].
 
 To apply any of `--binstubs`, `--deployment`, `--path`, or `--without` every
 time `bundle install` is run, use `bundle config` (see bundle-config(1)).
+
+* '--avoid=[<list>]'
+  A space-separated list of gems to skip during installation.
 
 * `--binstubs[=<directory>]`:
   Binstubs are scripts that wrap around executables. Bundler creates a small Ruby

--- a/spec/commands/install_spec.rb
+++ b/spec/commands/install_spec.rb
@@ -275,6 +275,19 @@ RSpec.describe "bundle install with gem sources" do
         expect(the_bundle).to include_gems "rack 1.0"
       end
 
+      it "avoids specifiied gem" do
+        p '--before bundle install'
+        bundle "install --avoid rack"
+
+        # lockfile = File.read(bundled_app("Gemfile.lock"))
+        # p 'before expectation'
+        # p the_bundle.locked_gems
+        # expect(lockfile).to match(/no dependencies/)
+        # p the_bundle.locked_gems.dependencies.keys.empty?
+        expect(the_bundle.locked_gems.dependencies.keys).not_to include('rack')
+        # expect(the_bundle).not_to include_gems("rack")
+      end
+
       it "allows running bundle install --system without deleting foo", :bundler => "< 3" do
         bundle "install", forgotten_command_line_options(:path => "vendor")
         bundle "install", forgotten_command_line_options(:system => true)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,7 @@ require "bundler/psyched_yaml"
 require "bundler/vendored_fileutils"
 require "uri"
 require "digest"
+require 'pry'
 
 if File.expand_path(__FILE__) =~ %r{([^\w/\.:\-])}
   abort "The bundler specs cannot be run from a path that contains special characters (particularly #{$1.inspect})"


### PR DESCRIPTION
Overall I decided to split this task into three phases, which themselves have the same structure.

1. Discovery.
2. Identify simplest solution & implement
3. Iterate (edge cases, sub-dependencies, user experience)

This is the first stage - Discovery.

Objectives: become familiar with some of the bundler domain, in particular focusing on the code paths for `bundle install`.
Tools: searching, logging, noting.

I started here: 
- [bundler/README.md at master · bundler/bundler · GitHub](https://github.com/bundler/bundler/blob/master/doc/contributing/README.md)
- [bundler/NEW_FEATURES.md at master · bundler/bundler · GitHub](https://github.com/bundler/bundler/blob/master/doc/development/NEW_FEATURES.md)
- Signed up to the community slack, absorb some of the info. 
Some exploration first. Run tests, diagram flow.


I decided to find what I thought was the simplest path to follow. I explored the `bundle install` command, and the current set of args it takes - there was similarity with the --without, --with args.

The first decision I made was to create a flag `--avoid` that takes a string of gem names separated by commas to specify gems to avoid installing.

Reading through the specs, I wrote a simple test and ran it to slowly discover how it worked.

run `bin/rspec spec/commands/install_spec.rb:278` to see an example of the output I logged to follow(there's a lot, fyi). 
```ruby
        # a shortened version is here:
      it "avoids specifiied gem" do
        gemfile <<-G
          source "#{file_uri_for(gem_repo1)}"
          gem "rack"
        G

        bundle "install --avoid rack"

        expect(the_bundle.locked_gems.dependencies.keys).not_to include('rack')
      end
```

If I started this challenge again
1. I'd be more intentional in the format of my logs - at times I lost track of where the logs were coming from.
2. I'd be more intentional in reproducing the flow on paper so I could quickly get back state when picking it up from day to day; I found i spent time reading through the logs to remember how it worked.


Next Steps - identify simplest solution & implement
1. Add a flag to the dependency that indicates it is to skipped during installation.


